### PR TITLE
added sed to updater

### DIFF
--- a/updater-current.sh
+++ b/updater-current.sh
@@ -221,3 +221,7 @@ tput setaf 5;echo "[+] Updating OnionSearch..."
 tput setaf 2;echo "[+] Done."
 
 ############################
+
+#fix updater on host system to pull from main branch
+sed -i 's/dev/main/g' /usr/share/updater/updater.sh
+


### PR DESCRIPTION
This fix leverages our new updater flow to fix the update script on host system. 

replaces "dev" with "main" in the wgets in updater.