### PR TITLE
fix: chromium policy rule for extensions

### DIFF
--- a/kali-config/common/includes.chroot/etc/chromium/policies/managed/test_policy.json
+++ b/kali-config/common/includes.chroot/etc/chromium/policies/managed/test_policy.json
@@ -20,7 +20,6 @@
   "DisablePluginFinder": true,
   "DisableSafeBrowsingProceedAnyway": true,
   "DnsPrefetchingEnabled": false,
-  "ExtensionInstallBlacklist": ["*"],
   "ExtensionInstallForcelist": [
     "cjpalhdlnbpafiamejdnhcphjbkeiagm",
     "gcbommkclmclpchllfjekcdonpmejbdp"


### PR DESCRIPTION
Get rid of `ExtensionInstallBlacklist` to permit users to install their own custom extensions.