### PR TITLE
fix: chrome policy rule for developer tools

### DIFF
--- a/kali-config/common/includes.chroot/etc/chromium/policies/managed/test_policy.json
+++ b/kali-config/common/includes.chroot/etc/chromium/policies/managed/test_policy.json
@@ -11,7 +11,7 @@
   "DefaultGeolocationSetting": 0,
   "DefaultNotificationsSetting": 2,
   "DefaultPopupsSetting": 2,
-  "DeveloperToolsDisabled": true,
+  "DeveloperToolsDisabled": false,
   "DisabledPlugins": [
     "Chrome PDF Viewer",
     "Java",


### PR DESCRIPTION
Chromium Developer Tools are a valuable tool for OSINT for retrieving IDs, downloading images, etc., and should be enabled in my opinion.