### PR TITLE
Vortimo debian package and chrome extenstion bootstrap

### DIFF
--- a/kali-config/common/hooks/normal/osint-packages.chroot
+++ b/kali-config/common/hooks/normal/osint-packages.chroot
@@ -135,4 +135,11 @@ chmod +x /usr/share/updater/updater.sh
 chmod +x /etc/skel/Desktop/Updater.desktop
 chmod +x /usr/bin/alias-generator
 rm /etc/xdg/menus/applications-merged/kali-applications.menu
+
+# Install Vortimo
+vortimo_debian=$(curl -s https://www.vortimo.com/down/ | grep --color -E "[^\S ]*Vortimo-.*[0-9].deb" -o | awk -F '="' '{print $2}')
+vortimo_package=$(echo $vortimo_debian | awk -F '/' '{print $NF}')
+curl -O -s $vortimo_debian
+dpkg -i $vortimo_package
+rm $vortimo_package
 EOS

--- a/kali-config/common/includes.chroot/etc/chromium/policies/managed/test_policy.json
+++ b/kali-config/common/includes.chroot/etc/chromium/policies/managed/test_policy.json
@@ -22,7 +22,8 @@
   "DnsPrefetchingEnabled": false,
   "ExtensionInstallForcelist": [
     "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-    "gcbommkclmclpchllfjekcdonpmejbdp"
+    "gcbommkclmclpchllfjekcdonpmejbdp",
+    "engmbahfeipfbgcjnjgekgkpmdfhkicn"
   ],
   "HomepageIsNewTabPage": true,
   "HomepageLocation": "https://tracelabs.org/",


### PR DESCRIPTION
This will install both the Vortimo Debian Package and the Chromium Extension but will **not** configure the Vortimo application to read from chromium.